### PR TITLE
Fix/disable fetch interceptor

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
-import './utils/fetchInterceptor'; // Block broken RSS proxy requests
+// import './utils/fetchInterceptor'; // disabled to stop blocking feeds
 
 // Global error handler for unhandled errors
 window.onerror = function(message, source, lineno, colno, error) {

--- a/src/utils/fetchInterceptor.ts
+++ b/src/utils/fetchInterceptor.ts
@@ -1,78 +1,8 @@
-/**
- * Fetch interceptor to block broken RSS proxy requests
- * This prevents 404 errors from broken RSS feeds
- */
+// src/utils/fetchInterceptor.ts
+// Disabled interceptor to avoid blocking legitimate fetch requests.
+// The exported API is preserved so existing imports continue to work.
+
 export function setupFetchInterceptor(): void {
-  // Only set up interceptor once
-  if ((window as any).__rssInterceptorSetup) {
-    return;
-  }
-
-  const originalFetch = window.fetch;
-
-  window.fetch = function(...args: Parameters<typeof fetch>): Promise<Response> {
-    const url = args[0];
-
-    // Block broken RSS proxy URLs
-    if (typeof url === 'string') {
-      const urlLower = url.toLowerCase();
-      
-      // Block broken RSS proxy patterns
-      if (
-        urlLower.includes('rss-proxy') ||
-        urlLower.includes('m%2fblog%2frss%2f') ||
-        urlLower.includes('ftechnology') ||
-        urlLower.includes('fnews') ||
-        urlLower.includes('fetch-rss') ||
-        (urlLower.includes('/api/rss-proxy') && (
-          urlLower.includes('techcrunch.com/rss') ||
-          urlLower.includes('venturebeat.com/feed') ||
-          urlLower.includes('arstechnica.com/feed')
-        ))
-      ) {
-        console.log('🚫 Blocked broken RSS request:', url);
-
-        // Return empty XML response for RSS feeds to prevent XML parsing errors
-        const isRSSRequest = urlLower.includes('rss') || urlLower.includes('feed') || urlLower.includes('xml');
-        const emptyRSSXML = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-  <channel>
-    <title>Replaced Feed</title>
-    <description>This feed has been replaced with working alternatives</description>
-    <items></items>
-  </channel>
-</rss>`;
-        
-        return Promise.resolve(
-          new Response(
-            isRSSRequest ? emptyRSSXML : JSON.stringify({
-              items: [],
-              articles: [],
-              status: 'replaced',
-              message: 'RSS feed replaced with free sources'
-            }),
-            {
-              status: 200,
-              headers: {
-                'Content-Type': isRSSRequest ? 'application/xml' : 'application/json',
-                'X-RSS-Intercepted': 'true'
-              }
-            }
-          )
-        );
-      }
-    }
-
-    // Allow all other requests
-    return originalFetch.apply(this, args);
-  };
-
-  (window as any).__rssInterceptorSetup = true;
-  console.log('✅ Broken RSS feeds interceptor activated');
+  // Interceptor intentionally disabled.
+  // If you need to re-enable it later, implement a tested toggle or provide setup/teardown APIs.
 }
-
-// Auto-setup on import
-if (typeof window !== 'undefined') {
-  setupFetchInterceptor();
-}
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables the RSS fetch interceptor to stop blocking feeds by commenting the import and stubbing its implementation.
> 
> - **Network / Runtime**:
>   - **Disable RSS fetch interceptor**:
>     - Comment out `import './utils/fetchInterceptor'` in `src/main.tsx`.
>     - Replace `src/utils/fetchInterceptor.ts` with a no-op `setupFetchInterceptor` to preserve the API without intercepting requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69f66c550e05226dc917877c6c5b386d7aa7f946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->